### PR TITLE
适配新版 Google Play 服务

### DIFF
--- a/app/src/main/java/com/kooritea/fcmfix/xposed/ReconnectManagerFix.java
+++ b/app/src/main/java/com/kooritea/fcmfix/xposed/ReconnectManagerFix.java
@@ -208,8 +208,11 @@ public class ReconnectManagerFix extends XposedModule {
         final SharedPreferences.Editor editor = sharedPreferences.edit();
         try{
             Class<?> heartbeatChimeraAlarm =  XposedHelpers.findClass("com.google.android.gms.gcm.connection.HeartbeatChimeraAlarm",loadPackageParam.classLoader);
-            final Class<?> timerClass = heartbeatChimeraAlarm.getConstructors()[0].getParameterTypes()[3];
+            Class<?> timerClass = heartbeatChimeraAlarm.getConstructors()[0].getParameterTypes()[3];
             editor.putString("timer_class", timerClass.getName());
+            if(timerClass.getDeclaredMethods().length == 0){
+                timerClass = timerClass.getSuperclass();
+            }
             for(Method method : timerClass.getDeclaredMethods()){
                 if(method.getParameterTypes().length == 1 && method.getParameterTypes()[0] == long.class && Modifier.isFinal(method.getModifiers()) && Modifier.isPublic(method.getModifiers())){
                     editor.putString("timer_settimeout_method", method.getName());


### PR DESCRIPTION
新版（我这边 22.33.15）貌似把之前 `HeartbeatChimeraAlarm` 构造方法里的第四个参数对应的类，又套了一层继承……

暂时先用 `getSuperclass()` 代一下，应该不至于后面又嵌套继承吧……

![image](https://user-images.githubusercontent.com/3889846/188870885-0795d316-e657-4190-ae18-3ea947408a0b.png)
![image](https://user-images.githubusercontent.com/3889846/188870933-8de7fa21-9c74-47db-bc57-4373d2819b84.png)
![image](https://user-images.githubusercontent.com/3889846/188871017-1fc948dc-7395-4523-86ea-9af2ab5de575.png)

