### PR TITLE
适配新版 Google Play 服务 v2

### DIFF
--- a/app/src/main/java/com/kooritea/fcmfix/xposed/ReconnectManagerFix.java
+++ b/app/src/main/java/com/kooritea/fcmfix/xposed/ReconnectManagerFix.java
@@ -217,10 +217,10 @@ public class ReconnectManagerFix extends XposedModule {
         try{
             Class<?> heartbeatChimeraAlarm =  XposedHelpers.findClass("com.google.android.gms.gcm.connection.HeartbeatChimeraAlarm",loadPackageParam.classLoader);
             Class<?> timerClass = heartbeatChimeraAlarm.getConstructors()[0].getParameterTypes()[3];
-            editor.putString("timer_class", timerClass.getName());
-            if(timerClass.getDeclaredMethods().length == 0){
+            if (timerClass.getDeclaredMethods().length == 0) {
                 timerClass = timerClass.getSuperclass();
             }
+            editor.putString("timer_class", timerClass.getName());
             for(Method method : timerClass.getDeclaredMethods()){
                 if(method.getParameterTypes().length == 1 && method.getParameterTypes()[0] == long.class && Modifier.isFinal(method.getModifiers()) && Modifier.isPublic(method.getModifiers())){
                     editor.putString("timer_settimeout_method", method.getName());


### PR DESCRIPTION
调换了一下往 SP 里写的顺序，之前的改动虽然可以正确找到方法了，但是却忘了在实际 hook 的时候拿的不是父类的……

需要删除 `/data/data/com.google.android.gms/shared_prefs/fcmfix_config.xml` 或更新 Google Play 服务，以触发 更新 hook 位置，修改 `timer_class` 字段（