### PR TITLE
修复 MIUI 13 应用广播 404 错误(#77)

### DIFF
--- a/app/src/main/java/com/kooritea/fcmfix/xposed/AutoStartFix.java
+++ b/app/src/main/java/com/kooritea/fcmfix/xposed/AutoStartFix.java
@@ -78,18 +78,23 @@ public class AutoStartFix extends XposedModule {
     }
 
     protected void startHookRemovePowerPolicy(){
-        Class<?> AutoStartManagerService = XposedHelpers.findClass("com.miui.server.smartpower.SmartPowerPolicyManager",loadPackageParam.classLoader);;
-        XposedUtils.findAndHookMethodAnyParam(AutoStartManagerService,"shouldInterceptService",new XC_MethodHook() {
+        try {
+            // MIUI13
+            Class<?> AutoStartManagerService = XposedHelpers.findClass("com.miui.server.smartpower.SmartPowerPolicyManager",loadPackageParam.classLoader);
+            XposedUtils.findAndHookMethodAnyParam(AutoStartManagerService,"shouldInterceptService",new XC_MethodHook() {
 
-            @Override
-            protected void afterHookedMethod(MethodHookParam param) throws Throwable {
-                Intent service = (Intent) param.args[0];
-                if("com.google.firebase.MESSAGING_EVENT".equals(service.getAction())){
-                    printLog("Disable MIUI Intercept: " +
-                            (service.getComponent() == null ? service.getPackage() : service.getComponent().getPackageName()));
-                    param.setResult(false);
+                @Override
+                protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+                    Intent service = (Intent) param.args[0];
+                    if("com.google.firebase.MESSAGING_EVENT".equals(service.getAction())){
+                        printLog("Disable MIUI Intercept: " +
+                                (service.getComponent() == null ? service.getPackage() : service.getComponent().getPackageName()));
+                        param.setResult(false);
+                    }
                 }
-            }
-        });
+            });
+        } catch (XposedHelpers.ClassNotFoundError | NoSuchMethodError  e) {
+            printLog("No Such Method com.miui.server.smartpower.SmartPowerPolicyManager.shouldInterceptService");
+        }
     }
 }

--- a/app/src/main/java/com/kooritea/fcmfix/xposed/AutoStartFix.java
+++ b/app/src/main/java/com/kooritea/fcmfix/xposed/AutoStartFix.java
@@ -13,6 +13,7 @@ public class AutoStartFix extends XposedModule {
     public AutoStartFix(XC_LoadPackage.LoadPackageParam loadPackageParam){
         super(loadPackageParam);
         this.startHook();
+        this.startHookRemovePowerPolicy();
     }
 
     protected void startHook(){
@@ -74,5 +75,21 @@ public class AutoStartFix extends XposedModule {
         }catch (XposedHelpers.ClassNotFoundError | NoSuchMethodError  e){
             printLog("No Such Method com.android.server.am.BroadcastQueueImpl.checkApplicationAutoStart");
         }
+    }
+
+    protected void startHookRemovePowerPolicy(){
+        Class<?> AutoStartManagerService = XposedHelpers.findClass("com.miui.server.smartpower.SmartPowerPolicyManager",loadPackageParam.classLoader);;
+        XposedUtils.findAndHookMethodAnyParam(AutoStartManagerService,"shouldInterceptService",new XC_MethodHook() {
+
+            @Override
+            protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+                Intent service = (Intent) param.args[0];
+                if("com.google.firebase.MESSAGING_EVENT".equals(service.getAction())){
+                    printLog("Disable MIUI Intercept: " +
+                            (service.getComponent() == null ? service.getPackage() : service.getComponent().getPackageName()));
+                    param.setResult(false);
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
- MIUI 13 的 `shouldInterceptService` 这个方法似乎会阻止应用启动服务，MIUI 12 未知
- 目前解开后，不再报 404 错误( #77 )
- 实时消息正常（如之前提到的 Nagram 可以在无后台的情况下正常被唤醒并推送），Discord、多邻国、Reddit 都主动推了（以前确实没见过他们推过消息hhhh）
- 但 Spark 邮箱的推送优先级为 REDUCED，即使广播成功、应用已被唤醒，也有可能没有实际发出通知，原因未知……（当时看的时候，Spark 的 FCM 的日志似乎已经拿到邮件内容了，但不清楚为什么没有发起推送，按理说不会这么设计？且没有触发 `Allow LocalNotification` 日志）