### PR TITLE
扩大 isFCMIntent 的范围

### DIFF
--- a/app/src/main/java/com/kooritea/fcmfix/xposed/XposedModule.java
+++ b/app/src/main/java/com/kooritea/fcmfix/xposed/XposedModule.java
@@ -282,7 +282,9 @@ public abstract class XposedModule {
 
     protected boolean isFCMIntent(Intent intent) {
         String action = intent.getAction();
-        if (action != null && (action.startsWith("com.google.android.c2dm.") || action.startsWith("com.google.firebase."))) {
+        if (action != null && (action.endsWith(".android.c2dm.intent.RECEIVE") ||
+                               "com.google.firebase.MESSAGING_EVENT".equals(action) ||
+                               "com.google.firebase.INSTANCE_ID_EVENT".equals(action))) {
             return true;
         } else {
             return false;

--- a/app/src/main/java/com/kooritea/fcmfix/xposed/XposedModule.java
+++ b/app/src/main/java/com/kooritea/fcmfix/xposed/XposedModule.java
@@ -282,7 +282,7 @@ public abstract class XposedModule {
 
     protected boolean isFCMIntent(Intent intent) {
         String action = intent.getAction();
-        if (action != null && action.endsWith(".android.c2dm.intent.RECEIVE")) {
+        if (action != null && (action.startsWith("com.google.android.c2dm.") || action.startsWith("com.google.firebase."))) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
以微信为例，他其中有如下相关intent filter：
```
com.google.firebase.MESSAGING_EVENT
com.google.firebase.INSTANCE_ID_EVENT
com.google.android.c2dm.intent.RECEIVE
```
我也不确定能不能解决什么问题，只是感觉这样比较保险