### PR TITLE
Add Support for Icebox SDK

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="com.catchingnow.icebox.SDK" />
+    <uses-permission android:name="web1n.stopapp.permission.disable_api" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/kooritea/fcmfix/MainActivity.java
+++ b/app/src/main/java/com/kooritea/fcmfix/MainActivity.java
@@ -26,6 +26,8 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -46,6 +48,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+
+import com.kooritea.fcmfix.util.IceboxUtils;
 
 public class MainActivity extends AppCompatActivity {
     private AppListAdapter appListAdapter;
@@ -94,7 +98,7 @@ public class MainActivity extends AppCompatActivity {
             List<AppInfo> _notAllowList = new ArrayList<>();
             List<AppInfo> _notFoundFcm = new ArrayList<>();
             PackageManager packageManager = getPackageManager();
-            for(PackageInfo packageInfo : packageManager.getInstalledPackages(PackageManager.GET_RECEIVERS)){
+            for(PackageInfo packageInfo : packageManager.getInstalledPackages(PackageManager.GET_RECEIVERS | PackageManager.MATCH_DISABLED_COMPONENTS | PackageManager.MATCH_UNINSTALLED_PACKAGES)) {
                 boolean flag = false;
                 AppInfo appInfo = new AppInfo(packageInfo);
                 if (packageInfo.receivers != null) {
@@ -185,6 +189,13 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
         RecyclerView recyclerView = findViewById(R.id.recycler_view);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
+
+        try {
+            if (ContextCompat.checkSelfPermission(this, IceboxUtils.SDK_PERMISSION) != PackageManager.PERMISSION_GRANTED) {
+                ActivityCompat.requestPermissions(this, new String[]{IceboxUtils.SDK_PERMISSION}, IceboxUtils.REQUEST_CODE);
+            }
+        } catch (Exception ignored) {
+        }
 
         try {
             FileInputStream fis = this.openFileInput("config.json");

--- a/app/src/main/java/com/kooritea/fcmfix/util/IceboxUtils.java
+++ b/app/src/main/java/com/kooritea/fcmfix/util/IceboxUtils.java
@@ -1,0 +1,98 @@
+package com.kooritea.fcmfix.util;
+
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Process;
+import android.util.Log;
+
+import androidx.annotation.RequiresPermission;
+import androidx.core.content.ContextCompat;
+
+import java.util.Objects;
+
+public class IceboxUtils extends BroadcastReceiver {
+    public final static int REQUEST_CODE = 0x2333;
+    public final static String PACKAGE_NAME = "com.catchingnow.icebox";
+    public final static String SDK_PERMISSION = PACKAGE_NAME + ".SDK";
+    private final static int FLAG_HIDDEN = 1 << 27;
+    private static final Uri PERMISSION_URI = Uri.parse("content://" + PACKAGE_NAME + ".SDK");
+    private static final Uri NO_PERMISSION_URI = Uri.parse("content://" + PACKAGE_NAME + ".STATE");
+    private static final String TAG = "IceboxUtils";
+    private static boolean isIceBoxWorking = false;
+    private static PendingIntent authorizedPendingIntent = null;
+
+    public static PendingIntent queryPermission(Context context) {
+        if (authorizedPendingIntent == null) {
+            authorizedPendingIntent = PendingIntent.getBroadcast(context, REQUEST_CODE, new Intent(context, IceboxUtils.class), PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        }
+        return authorizedPendingIntent;
+    }
+
+    private static boolean queryWorkMode(Context context) {
+        try {
+            Bundle extra = new Bundle();
+            extra.putParcelable("authorize", queryPermission(context));
+            Bundle bundle = context.getContentResolver().call(NO_PERMISSION_URI, "query_mode", null, extra);
+            assert bundle != null;
+            return !Objects.equals(bundle.getString("work_mode", null), "MODE_NOT_AVAILABLE");
+        } catch (Exception e) {
+            Log.e(TAG, "[icebox] queryWorkMode: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public static boolean isAppEnabled(Context context, String packageName) {
+        try {
+            ApplicationInfo applicationInfo = context.getPackageManager().getApplicationInfo(packageName, PackageManager.MATCH_UNINSTALLED_PACKAGES | PackageManager.MATCH_DISABLED_COMPONENTS);
+            return applicationInfo.enabled && (applicationInfo.flags | FLAG_HIDDEN) != applicationInfo.flags;
+        } catch (Exception e) {
+            Log.e(TAG, "[icebox] " + packageName + " " + e.getMessage());
+        }
+        return true;
+    }
+
+    @RequiresPermission(SDK_PERMISSION)
+    public static void enableApp(Context context, boolean enable, String... packageNames) {
+        int userHandle = Process.myUserHandle().hashCode();
+        Bundle extra = new Bundle();
+        extra.putParcelable("authorize", queryPermission(context));
+        extra.putStringArray("package_names", packageNames);
+        extra.putInt("user_handle", userHandle);
+        extra.putBoolean("enable", enable);
+        context.getContentResolver().call(PERMISSION_URI, "set_enable", null, extra);
+    }
+
+    public static void activeApp(Context context, String pkg) {
+        try {
+            if (!isIceBoxWorking) {
+                if (ContextCompat.checkSelfPermission(context, SDK_PERMISSION) != PackageManager.PERMISSION_GRANTED) {
+                    Log.e(TAG, "[icebox] need permission " + pkg);
+                    return;
+                }
+                if (!queryWorkMode(context)) {
+                    Log.e(TAG, "[icebox] is not working...");
+                    return;
+                }
+                isIceBoxWorking = true;
+            }
+            if (!isAppEnabled(context, pkg)) {
+                enableApp(context, true, pkg);
+                Log.i(TAG, "[icebox] successfully enable " + pkg);
+            } else {
+                Log.e(TAG, "[icebox] has been enabled " + pkg);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "[icebox] " + pkg + " " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+    }
+}

--- a/app/src/main/java/com/kooritea/fcmfix/xposed/XposedModule.java
+++ b/app/src/main/java/com/kooritea/fcmfix/xposed/XposedModule.java
@@ -143,11 +143,7 @@ public abstract class XposedModule {
             return true;
         }
         if(allowList != null){
-            for (String item : allowList) {
-                if (item.equals(packageName)) {
-                    return true;
-                }
-            }
+            return allowList.contains(packageName);
         }
         return false;
     }


### PR DESCRIPTION
When an FCM broadcast is received, the target application will now automatically wake up if it is frozen by Icebox. This ensures that the app can still respond to important FCM messages even when it has been placed in a frozen state by Icebox.

Additionally, it now supports selecting apps that are frozen.