### PR TITLE
BroadcastFix: update condition

### DIFF
--- a/app/src/main/java/com/kooritea/fcmfix/xposed/BroadcastFix.java
+++ b/app/src/main/java/com/kooritea/fcmfix/xposed/BroadcastFix.java
@@ -137,7 +137,8 @@ public class BroadcastFix extends XposedModule {
                     return;
                 }
                 Intent intent = (Intent) methodHookParam.args[finalIntent_args_index];
-                if(intent.getFlags() != Intent.FLAG_INCLUDE_STOPPED_PACKAGES && isFCMIntent(intent)){
+                // 介入条件：Intent未包含唤醒停止的pkg 且 Intent是FCM
+                if((intent.getFlags() & Intent.FLAG_INCLUDE_STOPPED_PACKAGES) == 0 && isFCMIntent(intent)){
                     String target;
                     if (intent.getComponent() != null) {
                         target = intent.getComponent().getPackageName();


### PR DESCRIPTION
现象：似乎唤醒从未生效，观察不到任何 broadcastIntentLocked hook里的日志。
排查代码，发现入口判断条件会包含[flag include stopped + 其他flag]的情况，不知道是否需要像我这样修改？